### PR TITLE
Update to 1.2.0-RC Raise DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ group = "com.wolt.arrow.detekt"
 
 repositories {
     mavenCentral()
+    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 java {
@@ -22,7 +23,7 @@ val ktlint: Configuration by configurations.creating
 dependencies {
     compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.22.0")
 
-    testImplementation(platform("io.arrow-kt:arrow-stack:1.1.5"))
+    testImplementation(platform("io.arrow-kt:arrow-stack:2.0.0-SNAPSHOT"))
     testImplementation("io.arrow-kt:arrow-core")
 
     testImplementation("io.gitlab.arturbosch.detekt:detekt-test:1.22.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ group = "com.wolt.arrow.detekt"
 
 repositories {
     mavenCentral()
-    maven("https://oss.sonatype.org/content/repositories/snapshots")
 }
 
 java {
@@ -23,7 +22,7 @@ val ktlint: Configuration by configurations.creating
 dependencies {
     compileOnly("io.gitlab.arturbosch.detekt:detekt-api:1.22.0")
 
-    testImplementation(platform("io.arrow-kt:arrow-stack:2.0.0-SNAPSHOT"))
+    testImplementation(platform("io.arrow-kt:arrow-stack:1.1.6-alpha.91"))
     testImplementation("io.arrow-kt:arrow-core")
 
     testImplementation("io.gitlab.arturbosch.detekt:detekt-test:1.22.0")

--- a/src/main/kotlin/com/wolt/arrow/detekt/rules/NoEffectScopeBindableValueAsStatement.kt
+++ b/src/main/kotlin/com/wolt/arrow/detekt/rules/NoEffectScopeBindableValueAsStatement.kt
@@ -9,20 +9,17 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
-import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
-import org.jetbrains.kotlin.descriptors.impl.PackageFragmentDescriptorImpl
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.isUsedAsStatement
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.getAbbreviatedType
 import org.jetbrains.kotlin.types.typeUtil.supertypes
 
 @RequiresTypeResolution
@@ -31,9 +28,28 @@ class NoEffectScopeBindableValueAsStatement(config: Config) : Rule(config) {
         javaClass.simpleName,
         Severity.Defect,
         "Having a bindable value inside effect scope used as a statement " +
-          "discards it's result and usually represents an error.",
+            "discards it's result and usually represents an error.",
         Debt.FIVE_MINS,
     )
+
+    override fun visitNamedFunction(function: KtNamedFunction) {
+        super.visitNamedFunction(function)
+
+        if (bindingContext == BindingContext.EMPTY) {
+            return
+        }
+
+        val receiverType = bindingContext[BindingContext.FUNCTION, function]
+            ?.extensionReceiverParameter
+            ?.type
+            ?: return
+
+        val isEffectScope = isBindableScope(receiverType) || receiverType.supertypes().any(::isBindableScope)
+
+        if (isEffectScope) {
+            EffectScopeVisitor().visitNamedFunction(function)
+        }
+    }
 
     override fun visitLambdaExpression(lambdaExpression: KtLambdaExpression) {
         super.visitLambdaExpression(lambdaExpression)
@@ -62,8 +78,8 @@ class NoEffectScopeBindableValueAsStatement(config: Config) : Rule(config) {
         ?.fqNameSafe
         ?.let {
             it == FqName("arrow.core.continuations.EffectScope") ||
-              it == FqName("arrow.core.continuations.EagerEffectScope") ||
-              it == FqName("arrow.core.raise.Raise")
+                it == FqName("arrow.core.continuations.EagerEffectScope") ||
+                it == FqName("arrow.core.raise.Raise")
         }
         ?: false
 
@@ -95,7 +111,7 @@ class NoEffectScopeBindableValueAsStatement(config: Config) : Rule(config) {
                         issue,
                         Entity.from(expression),
                         "This expression could be bound using the effect scope, but it is left unbound. " +
-                          "The value of this expression is discarded.",
+                            "The value of this expression is discarded.",
                     ),
                 )
             }
@@ -118,18 +134,16 @@ class NoEffectScopeBindableValueAsStatement(config: Config) : Rule(config) {
                     ?.fqNameSafe
                     ?.let { it in BindableFqNames } ?: false
 
-            val isPackage = (type.getAbbreviatedType()
-                ?.abbreviation
-                ?.constructor
-                ?.declarationDescriptor
-                ?.containingDeclaration as? PackageFragmentDescriptorImpl
-              )?.fqName?.asString() == "arrow.core.raise"
+            val isRaiseExtensionFunction = type.annotations.hasAnnotation(FqName("kotlin.ExtensionFunctionType")) &&
+                type
+                    .arguments
+                    .firstOrNull()
+                    ?.type
+                    ?.constructor
+                    ?.declarationDescriptor
+                    ?.fqNameSafe == FqName("arrow.core.raise.Raise")
 
-            val isRaiseEffect =
-                (type.getAbbreviatedType()?.abbreviation?.constructor?.declarationDescriptor?.name?.asString() == "EagerEffect") ||
-                  (type.getAbbreviatedType()?.abbreviation?.constructor?.declarationDescriptor?.name?.asString() == "Effect")
-
-            return isBindableFqNames || (isPackage && isRaiseEffect)
+            return isBindableFqNames || isRaiseExtensionFunction
         }
     }
 

--- a/src/test/kotlin/com/wolt/arrow/detekt/rules/NoRaiseBindableValueAsStatementTest.kt
+++ b/src/test/kotlin/com/wolt/arrow/detekt/rules/NoRaiseBindableValueAsStatementTest.kt
@@ -1,0 +1,414 @@
+package com.wolt.arrow.detekt.rules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.lintWithContext
+import io.kotest.matchers.collections.shouldHaveSize
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+internal class NoRaiseBindableValueAsStatementTest(private val env: KotlinCoreEnvironment) {
+
+    @Nested
+    @DisplayName("bindable variations")
+    inner class BindableVariations {
+        @Test
+        fun `reports unbound Either`() {
+            val code = """
+                import arrow.core.Either
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    Either.Right(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound Validated`() {
+            val code = """
+                import arrow.core.Validated
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    Validated.Valid(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound EagerEffect`() {
+            val code = """
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                import arrow.core.raise.eagerEffect
+
+                fun test(): Effect<Throwable, Int> = effect {
+                    eagerEffect<Throwable, Int> { 1 }
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound Effect`() {
+            val code = """
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    effect <Throwable, Int> { 1 }
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound Option`() {
+            val code = """
+                import arrow.core.Option
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    Option(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound Result`() {
+            val code = """
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    Result.success(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound Ior`() {
+            val code = """
+                import arrow.core.Ior
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    Ior.Right(5)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports bindable value with more than one level of inheritance`() {
+            val code = """
+            import arrow.core.raise.effect
+            import arrow.core.raise.Effect
+
+            abstract class MyEffect : Effect<Nothing, Int>
+
+            class MyEffectChild : MyEffect {
+                override suspend fun invoke(p1: Raise<Nothing>): Int = TODO()
+            }
+
+            fun test(): Effect<Throwable, Int> = effect {
+                MyEffectChild()
+                1
+            }
+        """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+    }
+
+    @Nested
+    @DisplayName("effect scope variations")
+    inner class EffectScopeVariations {
+        @Test
+        fun `reports unbound value inside effect {} scope`() {
+            val code = """
+                import arrow.core.Either
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+                
+                fun test(): Effect<Throwable, Int> = effect {
+                    Either.Right(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside eagerEffect {} scope`() {
+            val code = """
+                import arrow.core.Either
+                import arrow.core.raise.EagerEffect
+                import arrow.core.raise.eagerEffect
+                
+                fun test(): EagerEffect<Throwable, Int> = eagerEffect {
+                    Either.Right(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside either {} scope`() {
+            val code = """
+                import arrow.core.Either
+                import arrow.core.raise.either
+                
+                suspend fun test(): Either<Throwable, Int> = either {
+                    Either.Right(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside option {} scope`() {
+            val code = """
+                import arrow.core.Option
+                import arrow.core.raise.option
+                
+                suspend fun test(): Option<Int> = option {
+                    Option(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside nullable {} scope`() {
+            val code = """
+                import arrow.core.Option
+                import arrow.core.raise.nullable
+                
+                suspend fun test(): Int? = nullable {
+                    Option(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside ior {} scope`() {
+            val code = """
+                import arrow.core.Ior
+                import arrow.typeclasses.Semigroup
+                import arrow.core.raise.ior
+                
+                suspend fun test(): Ior<List<Int>, Int> = ior(Semigroup.list()) {
+                    Ior.Right(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside result {} scope`() {
+            val code = """
+                import arrow.core.raise.result
+                
+                suspend fun test(): Result<Int> = result {
+                    Result.success(1)
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+
+        @Test
+        fun `reports unbound value inside scope with more than one level of inheritance`() {
+            val code = """
+                import arrow.core.None
+                import arrow.core.raise.Raise
+                import arrow.core.raise.Effect
+                import arrow.core.raise.effect
+
+                abstract class MyOptionScope : Raise<None>
+                
+                class MyChildScope : MyOptionScope() {
+                    override fun raise(r: None): Nothing = TODO()
+                }
+                
+                object myChildScope {
+                    inline operator fun <A> invoke(crossinline f: suspend MyChildScope.() -> A): Effect<Throwable, A> = TODO()
+                }
+
+                fun test(): Effect<Throwable, Int> = myChildScope {
+                    effect <Throwable, Int> { 1 }
+                    1
+                }
+            """
+            val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+            findings shouldHaveSize 1
+        }
+    }
+
+    @Test
+    fun `reports unbound reference expression`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+            
+            val e = Either.Right(1)
+            
+            fun test(): Either<Throwable, Int> = either {
+                e
+                1
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports unbound reference expression with dot qualified expression`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+            
+            object T {
+                val e = Either.Right(1)
+            }
+            
+            fun test(): Either<Throwable, Int> = either {
+                T.e
+                1
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports unbound call expression`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+    
+            fun a() = Either.Right(1)
+    
+            fun test(): Either<Throwable, Int> = either {
+                a()
+                1
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports unbound implicit return with Unit type`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+
+            fun test(): Either<Throwable, Unit> = either {
+                Either.Right(1)
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports unbound value inside an if`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+
+            fun test(): Either<Throwable, Int> = either {
+                if (true) {
+                    Either.Right(1)
+                }
+                1
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `reports unbound value inside nested context`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+
+            fun test(): Either<Throwable, Unit> = either {
+                with (1) { Either.Right(this) }
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 1
+    }
+
+    @Test
+    fun `does not report if the value is handled`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+            import arrow.core.getOrHandle
+
+            fun test(): Either<Throwable, Unit> = either {
+                Either.Right(1).getOrHandle { 1 }
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
+
+    @Test
+    fun `does not report if the value is bound`() {
+        val code = """
+            import arrow.core.Either
+            import arrow.core.raise.either
+
+            fun test(): Either<Throwable, Unit> = either {
+                Either.Right(1).bind()
+            }
+        """
+        val findings = NoEffectScopeBindableValueAsStatement(Config.empty).lintWithContext(env, code)
+        findings shouldHaveSize 0
+    }
+}


### PR DESCRIPTION
This PR updates the rules to also check for `Raise`, I ran into some issues _detekt` Effect since it's now a _typealias_ and since it's a `suspend lambda` it seems all information about the _typealias_ get completely erased.

At least I could not find any reference to it when debugging the rules.